### PR TITLE
Add .gitignore for Node.js artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Node.js dependencies
+node_modules/
+
+# Next.js build output
+.next/
+
+# Production build output
+out/
+
+# Environment variables
+.env
+.env.*
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS metadata
+.DS_Store
+
+# Editor directories and files
+.idea/
+.vscode/
+


### PR DESCRIPTION
## Summary
- add standard Node.js `.gitignore` to avoid committing dependencies and build output

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b441e140832199d624b2578584c0