### PR TITLE
test: add Sidebar component test

### DIFF
--- a/__tests__/Sidebar.test.js
+++ b/__tests__/Sidebar.test.js
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import Sidebar from '../components/Sidebar';
+
+// Mock next/link to avoid router errors during tests
+jest.mock('next/link', () => {
+  return ({ children, href }) => <a href={href}>{children}</a>;
+});
+
+describe('Sidebar', () => {
+  it('renders all navigation links', () => {
+    render(<Sidebar />);
+    const links = ['Dashboard', 'Contacts', 'Quotes', 'Projects', 'Reports', 'Settings'];
+    links.forEach((link) => {
+      expect(screen.getByText(link)).toBeInTheDocument();
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "tradex-ui-refresh",
   "version": "0.1.0",
@@ -6,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "autoprefixer": "^10.4.12",
@@ -15,5 +15,10 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "^3.1.8"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^5.17.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Sidebar component unit test with React Testing Library
- set up Next.js Jest configuration
- add jest and @testing-library packages
- expose `npm test` script

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b706a6308321814e42e1f1740d42