### PR TITLE
Add Recharts dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is the initial boilerplate for your TradeX SaaS platform built with Next.js and Tailwind CSS.
 
+Charts on the dashboard are rendered using [Recharts](https://recharts.org/).
+
 ## Prerequisites
 
 - **Node.js**: version 16.14 or later is recommended to build and run the application.
@@ -14,6 +16,8 @@ Install dependencies and start the development server:
 npm install
 npm run dev
 ```
+
+This command installs all project dependencies, including Recharts for the dashboard graphs.
 
 Open your browser at `http://localhost:3000` to view the app. You should see a sidebar with navigation links, a top bar titled "Dashboard", and a welcome message in the main area.
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postcss": "^8.4.18",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tailwindcss": "^3.1.8"
+    "tailwindcss": "^3.1.8",
+    "recharts": "^2.9.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- document Recharts usage in README
- instruct to install all dependencies including Recharts
- add `recharts` library to project dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f3985e608321a17e1e1f895fefcc